### PR TITLE
Fix MJD time parsing

### DIFF
--- a/bin/synthms
+++ b/bin/synthms
@@ -71,7 +71,18 @@ def lofar_num2nu(num, station, n_chan = 4, nu_clk = 200.e6):
     return f, np.mean(f), delta_nu
 
 def timestamp(mjds):
-    jd = Time(mjds / (3600. * 24.), format='mjd')
+    """
+    Returns date string suitable for use in filenames
+
+    Parameters
+    ----------
+    mjds: Modified Julian Date in seconds
+
+    Returns
+    -------
+    date: date string
+    """
+    jd = Time(mjds, format='mjd')
     year = jd.to_datetime().year
     month = jd.to_datetime().month
     day = jd.to_datetime().day


### PR DESCRIPTION
This PR fixes an issue (found by Tobias) with the time being converted incorrectly from seconds to days in the `timestamp` function.